### PR TITLE
Feat: Discord Threads support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.10
 tserver_mcver=1.21.1
 
 # Mod Properties
-mod_version=1.1.0+fabric.1.21.1
+mod_version=1.1.1+fabric.1.21.1
 maven_group=com.github.pinmacaroon.dchook
 archives_base_name=dchook
 

--- a/src/main/java/com/github/pinmacaroon/dchook/Hook.java
+++ b/src/main/java/com/github/pinmacaroon/dchook/Hook.java
@@ -44,6 +44,8 @@ public class Hook implements DedicatedServerModInitializer {
             "^https:\\/\\/(ptb\\.|canary\\.)?discord\\.com\\/api\\/webhooks\\/\\d+\\/.+$"
     );
 
+    public static URI WEBHOOK_URI; 
+    
     public static volatile Bot BOT;
     public static boolean BOT_ENABLED = false;
 
@@ -75,18 +77,17 @@ public class Hook implements DedicatedServerModInitializer {
         if(ModConfigs.FUNCTIONS_BOT_ENABLED) bottedStart();
         else botlessStart();
         
-        if(ModConfigs.IS_THREAD) IS_THREAD = true;
-
-        try {
-            URI webhook_url;
-            if(ModConfigs.IS_THREAD) {
-                webhook_url = URI.create(ModConfigs.WEBHOOK_URL + "?thread_id=" + ModConfigs.THREAD_ID);
-            } else {
-                webhook_url = URI.create(ModConfigs.WEBHOOK_URL);
-            }
+        if(ModConfigs.IS_THREAD) {
+            IS_THREAD = true;
+            WEBHOOK_URI = URI.create(ModConfigs.WEBHOOK_URL + "?thread_id=" + ModConfigs.THREAD_ID);
+        } else {
+            WEBHOOK_URI = URI.create(ModConfigs.WEBHOOK_URL);
+        }
+        
+        try {    
             HttpRequest get_webhook = HttpRequest.newBuilder()
                     .GET()
-                    .uri(webhook_url)
+                    .uri(WEBHOOK_URI)
                     .build();
 
             HttpResponse<String> response = HTTPCLIENT.send(get_webhook, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/com/github/pinmacaroon/dchook/Hook.java
+++ b/src/main/java/com/github/pinmacaroon/dchook/Hook.java
@@ -47,6 +47,7 @@ public class Hook implements DedicatedServerModInitializer {
     public static volatile Bot BOT;
     public static boolean BOT_ENABLED = false;
 
+    private boolean IS_THREAD = false;
     private static MinecraftServer MINECRAFT_SERVER;
 
     public static MinecraftServer getGameServer() {
@@ -73,11 +74,19 @@ public class Hook implements DedicatedServerModInitializer {
 
         if(ModConfigs.FUNCTIONS_BOT_ENABLED) bottedStart();
         else botlessStart();
+        
+        if(ModConfigs.IS_THREAD) IS_THREAD = true;
 
         try {
+            URI webhook_url;
+            if(ModConfigs.IS_THREAD) {
+                webhook_url = URI.create(ModConfigs.WEBHOOK_URL + "?thread_id=" + ModConfigs.THREAD_ID);
+            } else {
+                webhook_url = URI.create(ModConfigs.WEBHOOK_URL);
+            }
             HttpRequest get_webhook = HttpRequest.newBuilder()
                     .GET()
-                    .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                    .uri(webhook_url)
                     .build();
 
             HttpResponse<String> response = HTTPCLIENT.send(get_webhook, HttpResponse.BodyHandlers.ofString());
@@ -96,7 +105,11 @@ public class Hook implements DedicatedServerModInitializer {
                         Thread.onSpinWait();
                     }
                     BOT.setGUILD_ID(body.get("guild_id").getAsLong());
-                    BOT.setCHANNEL_ID(body.get("channel_id").getAsLong());
+                    if (IS_THREAD) {
+                        BOT.setCHANNEL_ID(Long.parseLong(ModConfigs.THREAD_ID));
+                    } else {
+                        BOT.setCHANNEL_ID(body.get("channel_id").getAsLong());
+                    }
                 });
                 bot_rutime_thread.start();
             }

--- a/src/main/java/com/github/pinmacaroon/dchook/conf/ModConfigs.java
+++ b/src/main/java/com/github/pinmacaroon/dchook/conf/ModConfigs.java
@@ -54,11 +54,11 @@ public class ModConfigs {
 
         configs.addDocumentationLine("Configure Discord connection related parameters:");
         configs.addKeyValuePair(new Pair<>("webhook.url", "https://discord.com/api/webhooks/000/ABCDEF"), "url of webhook");
-	configs.addDocumentationLine("Configure if webhook points to a thread");
-	configs.addKeyValuePair(new Pair<>("webhook.thread", false), "is channel a thread?");
-	configs.addDocumentationLine("Configure Thread ID if true. DON'T ADD ?thread_id PARAMETER TO THE WEBHOOK AS THE MOD AUTOMATICALLY INSERTS IT!");
-	configs.addKeyValuePair(new Pair<>("webhook.thread.id", "01234567890123456789"), "id of thread");
-	configs.addBlankLine();
+        configs.addDocumentationLine("Configure if webhook points to a thread");
+        configs.addKeyValuePair(new Pair<>("webhook.thread", false), "is channel a thread?");
+        configs.addDocumentationLine("Configure Thread ID if true. DON'T ADD ?thread_id PARAMETER TO THE WEBHOOK AS THE MOD AUTOMATICALLY INSERTS IT!");
+        configs.addKeyValuePair(new Pair<>("webhook.thread.id", "01234567890123456789"), "id of thread");
+        configs.addBlankLine();
 
         configs.addDocumentationLine("Configure messages sent:");
         configs.addKeyValuePair(new Pair<>("messages.server.starting", "The server is starting!"), "start message");
@@ -84,8 +84,8 @@ public class ModConfigs {
 
     private static void assignConfigs() {
         WEBHOOK_URL = CONFIG.getOrDefault("webhook.url", "");
-	IS_THREAD = CONFIG.getOrDefault("webhook.thread", false);
-	THREAD_ID = CONFIG.getOrDefault("webhook.thread.id", "");
+        IS_THREAD = CONFIG.getOrDefault("webhook.thread", false);
+        THREAD_ID = CONFIG.getOrDefault("webhook.thread.id", "");
         MESSAGES_SERVER_STARTING = CONFIG.getOrDefault("messages.server.starting", "messages.server.starting");
         MESSAGES_SERVER_STARTED = CONFIG.getOrDefault("messages.server.started", "messages.server.started");
         MESSAGES_SERVER_STOPPED = CONFIG.getOrDefault("messages.server.stopped", "messages.server.stopped");

--- a/src/main/java/com/github/pinmacaroon/dchook/conf/ModConfigs.java
+++ b/src/main/java/com/github/pinmacaroon/dchook/conf/ModConfigs.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 public class ModConfigs {
     public static SimpleConfig CONFIG;
     public static String WEBHOOK_URL;
+    public static String THREAD_ID;
     public static String MESSAGES_SERVER_STARTING;
     public static String MESSAGES_SERVER_STOPPED;
     public static String MESSAGES_SERVER_STARTED;
@@ -16,6 +17,7 @@ public class ModConfigs {
     public static String MESSAGES_BOT_LIST;
     public static String MESSAGES_BOT_MODS_LIST;
     public static String MESSAGES_BOT_MODS_NONE;
+    public static boolean IS_THREAD;
     public static boolean FUNCTIONS_ALLOWOOCMESSAGES;
     public static boolean MESSAGES_SERVER_STARTING_ALLOWED;
     public static boolean MESSAGES_SERVER_STOPPED_ALLOWED;
@@ -52,7 +54,11 @@ public class ModConfigs {
 
         configs.addDocumentationLine("Configure Discord connection related parameters:");
         configs.addKeyValuePair(new Pair<>("webhook.url", "https://discord.com/api/webhooks/000/ABCDEF"), "url of webhook");
-        configs.addBlankLine();
+	configs.addDocumentationLine("Configure if webhook points to a thread");
+	configs.addKeyValuePair(new Pair<>("webhook.thread", false), "is channel a thread?");
+	configs.addDocumentationLine("Configure Thread ID if true. DON'T ADD ?thread_id PARAMETER TO THE WEBHOOK AS THE MOD AUTOMATICALLY INSERTS IT!");
+	configs.addKeyValuePair(new Pair<>("webhook.thread.id", "01234567890123456789"), "id of thread");
+	configs.addBlankLine();
 
         configs.addDocumentationLine("Configure messages sent:");
         configs.addKeyValuePair(new Pair<>("messages.server.starting", "The server is starting!"), "start message");
@@ -78,6 +84,8 @@ public class ModConfigs {
 
     private static void assignConfigs() {
         WEBHOOK_URL = CONFIG.getOrDefault("webhook.url", "");
+	IS_THREAD = CONFIG.getOrDefault("webhook.thread", false);
+	THREAD_ID = CONFIG.getOrDefault("webhook.thread.id", "");
         MESSAGES_SERVER_STARTING = CONFIG.getOrDefault("messages.server.starting", "messages.server.starting");
         MESSAGES_SERVER_STARTED = CONFIG.getOrDefault("messages.server.started", "messages.server.started");
         MESSAGES_SERVER_STOPPED = CONFIG.getOrDefault("messages.server.stopped", "messages.server.stopped");

--- a/src/main/java/com/github/pinmacaroon/dchook/util/EventListeners.java
+++ b/src/main/java/com/github/pinmacaroon/dchook/util/EventListeners.java
@@ -12,6 +12,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 
 public class EventListeners {
@@ -28,7 +29,7 @@ public class EventListeners {
 
             HttpRequest post = HttpRequest.newBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                    .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                    .uri(Hook.WEBHOOK_URI)
                     .header("Content-Type", "application/json")
                     .build();
 
@@ -48,7 +49,7 @@ public class EventListeners {
 
                     HttpRequest post = HttpRequest.newBuilder()
                             .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                            .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                            .uri(Hook.WEBHOOK_URI)
                             .header("Content-Type", "application/json")
                             .build();
 
@@ -60,7 +61,7 @@ public class EventListeners {
                 }
 
                 if (ModConfigs.FUNCTIONS_PROMOTIONS_ENABLED) {
-                    PromotionProvider.sendPromotion(URI.create(ModConfigs.WEBHOOK_URL));
+                    PromotionProvider.sendPromotion(Hook.WEBHOOK_URI);
                 }
             });
 
@@ -72,7 +73,7 @@ public class EventListeners {
 
                 HttpRequest post = HttpRequest.newBuilder()
                         .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                        .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                        .uri(Hook.WEBHOOK_URI)
                         .header("Content-Type", "application/json")
                         .build();
 
@@ -94,7 +95,7 @@ public class EventListeners {
 
             HttpRequest post = HttpRequest.newBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                    .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                    .uri(Hook.WEBHOOK_URI)
                     .header("Content-Type", "application/json")
                     .build();
 
@@ -126,7 +127,7 @@ public class EventListeners {
 
             HttpRequest post = HttpRequest.newBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                    .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                    .uri(Hook.WEBHOOK_URI)
                     .header("Content-Type", "application/json")
                     .build();
 
@@ -146,7 +147,7 @@ public class EventListeners {
 
             HttpRequest post = HttpRequest.newBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(Hook.GSON.toJson(request_body)))
-                    .uri(URI.create(ModConfigs.WEBHOOK_URL))
+                    .uri(Hook.WEBHOOK_URI)
                     .header("Content-Type", "application/json")
                     .build();
 


### PR DESCRIPTION
While you can add thread support directly on the webhook by putting in the "?thread_id=" param in the URL, the integrated bot does not recognize it, and only posts on the main channel.

This PR adds thread support for the bot and webhook without touching "?thread_id=" inside config.

Added:
webhook.thread: Boolean = false
webhook.thread.id: String = 01234567890123456789